### PR TITLE
fix(portal): fixes broken org switcher 

### DIFF
--- a/portal/src/components/sidebar-new.js
+++ b/portal/src/components/sidebar-new.js
@@ -74,7 +74,7 @@ const BusinessSelect = (props) => {
     }
 
     const change = (ev) => {
-        const selected = data.businesses.find(e => e.id === ev.target.value);
+        const selected = data.businesses.find(e => e.id === parseInt(ev.target.value));
         props.setSelected(selected);
     }
 


### PR DESCRIPTION
closes #40

The dropdown fails to find the correctly selected org due to mismatched types. This PR casts the input string to int for safe comparison.